### PR TITLE
Remove --ask-pass from main playbook command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Run the requirements playbook using the root password you specified while instal
 
 Run the main playbook with the new users password you specified in the *variables.yml* file:
 
-    ansible-playbook --inventory hosts.yml --ask-pass main-playbook.yml
+    ansible-playbook --inventory hosts.yml main-playbook.yml
 
 &nbsp;
 


### PR DESCRIPTION
When I tried running the command for running `main-playbook.yml` for the first time, it kept asking me for a password and kept hanging. So I removed the `--ask-password` flag, it started prompting me for the password for my SSH key and it started working.

My server is running Debian 12 if this is some sort of edgecase thing, but this actually seems like the more logical thing to do? I mean after all, we did create and put the SSH key on the server in the previous step exactly for this purpose.