### PR TITLE
Allow whois on ufw outgoing

### DIFF
--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -35,6 +35,7 @@
         direction: out
         to_port: "{{ item }}"
       with_items:
+        - "43/tcp"
         - "53"
         - "123"
         - "80"

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -35,7 +35,7 @@
         direction: out
         to_port: "{{ item }}"
       with_items:
-        - "43/tcp"
+        - "43"
         - "53"
         - "123"
         - "80"


### PR DESCRIPTION
psad hangs on whois for ages if it can't contact whois, and it can't add in whois data. Adding TCP 43 to ufw just, well, lets it grab the info it needs.