### PR TITLE
Lynis - Update to new GPG installation method

### DIFF
--- a/roles/lynis/tasks/main.yml
+++ b/roles/lynis/tasks/main.yml
@@ -1,8 +1,20 @@
+    - name: update and upgrade
+      become: true
+      apt:
+        update_cache: yes
+        upgrade: yes
+
+    - name: install lynis dependencies
+      become: true
+      apt:
+        name: gpg
+        state: present
+
     - name: prepare lynis installation
       become: true
       shell: |
-        wget -O - https://packages.cisofy.com/keys/cisofy-software-public.key | sudo apt-key add -
-        echo "deb https://packages.cisofy.com/community/lynis/deb/ stable main" | sudo tee /etc/apt/sources.list.d/cisofy-lynis.list
+        curl -fsSL https://packages.cisofy.com/keys/cisofy-software-public.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/cisofy-software-public.gpg
+        echo "deb [arch=amd64,arm64 signed-by=/etc/apt/trusted.gpg.d/cisofy-software-public.gpg] https://packages.cisofy.com/community/lynis/deb/ stable main" | sudo tee /etc/apt/sources.list.d/cisofy-lynis.list
 
     - name: update and upgrade
       become: true


### PR DESCRIPTION
Lynis has a newer installation method that doesn't use the deprecated apt-key approach.

This was updated based on the [installation instructions for Debian](https://packages.cisofy.com/community/#debian-ubuntu).