### PR TITLE
Mail - Allow using a different username than the from address.

### DIFF
--- a/roles/mail/tasks/main.yml
+++ b/roles/mail/tasks/main.yml
@@ -13,7 +13,7 @@
           set_from_header on
           from {{ mail_from }}
           auth on
-          user {{ mail_from }}
+          user {{ mail_username | default(mail_from) }}
           password {{ mail_pw }}
           account default: {{ mail_from }}
           aliases /etc/aliases


### PR DESCRIPTION
My SMTP server needs a separate username that is different than the email address the mail will be from, so we'll allow you to configure this. Note that it will default to the existing mail_from variable, just like it always did.