### PR TITLE
Update apt before requirements setup

### DIFF
--- a/roles/requirements/tasks/main.yml
+++ b/roles/requirements/tasks/main.yml
@@ -1,3 +1,7 @@
+    - name: apt update
+      apt:
+        update_cache: yes
+        upgrade: false
 
     - name: install sudo via apt
       apt:


### PR DESCRIPTION
On first-run my VMs didn't have any apt cache, so installing sudo would fail. To fix this, we'll run apt update before we attempt install. We *don't* run apt upgrade, we still leave that until the main playbook.