### PR TITLE
Requirements - Allow specifying group names and disabling passwordless sudo

### DIFF
--- a/requirements-playbook.yml
+++ b/requirements-playbook.yml
@@ -1,6 +1,11 @@
     - name: Requirements-Playbook
       hosts: debian-server
       remote_user: root
+      vars:
+        sshusers_group: sshusers
+        suusers_group: suusers
+        sudousers_group: sudousers
+        passwordless_sudo: true
       vars_files: ./group_vars/variables.yml
 
       roles:

--- a/roles/requirements/tasks/main.yml
+++ b/roles/requirements/tasks/main.yml
@@ -5,33 +5,34 @@
 
     - name: create group for ssh users
       group:
-        name: sshusers
+        name: '{{ sshusers_group }}'
 
     - name: create group for su users
       group:
-        name: suusers
+        name: '{{ suusers_group }}'
 
     - name: create group for sudo users
       group:
-        name: sudousers
+        name: '{{ sudousers_group }}'
 
     - name: create new user with password, add to groups
       user:
         name: "{{ user_name }}"
-        password: "{{ user_pw | password_hash('sha512')}}"
-        groups: "sshusers, sudousers, suusers"
+        password: "{{ user_pw | password_hash('sha512') }}"
+        groups: "{{ sshusers_group }}, {{ sudousers_group }}, {{ suusers_group }}"
+        append: true
         shell: /bin/bash
 
     - name: limit sudo to sudousers groups
       lineinfile:
         path: /etc/sudoers
-        regexp: '^%sudousers'
-        line: '%sudousers   ALL=(ALL:ALL) ALL'
+        regexp: '^%{{ sudousers_group }}'
+        line: '%{{ sudousers_group }}   ALL=(ALL:ALL) ALL'
 
     - name: limit who can use su
       register: sustd
       shell: |
-        sudo dpkg-statoverride --update --add root suusers 4750 /bin/su
+        sudo dpkg-statoverride --update --add root {{ suusers_group }} 4750 /bin/su
       failed_when: 
         - sustd.rc != 0
         - '"exist" not in sustd.stderr' # this has to be changed: unsure how to skip the "already exist" error in other languages
@@ -45,6 +46,7 @@
         mode: 0440
         create: yes
         validate: 'visudo -cf %s'
+      when: passwordless_sudo == true
 
     - name: add authorized keys for new user
       authorized_key:


### PR DESCRIPTION
On my Debian VMs the default sudo group already exists, so I added the ability to configure the value of this group name so ew use the built-in one instead.

I also prefer not to disable the password requirement when sudo'ing, so I added a flag that allows you to disable the step that adds that step.

Since these are used multiple places in the task, I set their defaults in the example playbook rather than doing it line-by-line every time the variables are used.