### PR TITLE
Ensure SSH access if the play ends early

### DIFF
--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -1,3 +1,13 @@
+    - name: ufw - preemptively allow new SSH port
+      become: true
+      community.general.ufw:
+        rule: limit
+        direction: in
+        to_port: "{{ ssh_port }}"
+      notify: "firewall : restart ufw service"
+
+    - name: flush handlers to restart ufw
+      ansible.builtin.meta: flush_handlers
 
     - name: secure ssh configuration 
       become: true


### PR DESCRIPTION
I simply duplicated the `ufw` configuration for the SSH port into the `ssh` role. Now, if the play is terminated early by an error, the user hasn't completely lost access to the machine. (=

I figure it's not the worst to have this duplicated between the two roles; although ideally, perhaps, it'd be better to have it _only_ in the SSH role, and then have a firewall tag on it or something?

(Fixes #9.)