### PR TITLE
Make diffie-hellman moduli removal idempotent

### DIFF
--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -69,7 +69,14 @@
 
     - name: remove short diffie diffie-hellman
       become: true
-      shell: |
-        awk '$5 >= 3071' /etc/ssh/moduli | sudo tee /etc/ssh/moduli.tmp
-        mv /etc/ssh/moduli.tmp /etc/ssh/moduli
+      shell:
+        creates: /etc/ssh/moduli.short
+        cmd: |
+          cp /etc/ssh/moduli /etc/ssh/moduli.short
+          awk '$5 >= 3071' /etc/ssh/moduli | tee /etc/ssh/moduli.tmp
+          if ! cmp /etc/ssh/moduli /etc/ssh/moduli.tmp; then
+            mv /etc/ssh/moduli.tmp /etc/ssh/moduli
+          fi
       notify: restart ssh service
+      register: moduli_changed
+      changed_when: "'differ:' in moduli_changed.stdout"


### PR DESCRIPTION
This change to the shell snippet simply:

1. intentionally leaves a copy of the old version laying around (which subsequent Ansible invocations can check for, to see if this has already been executed); and
2. uses the output from `cmp` to determine whether any change was actually made to the file.

This gets rid of the 'changed: 1 task' notification when re-running the playbook on a host that's finished setting itself up.