### PR TITLE
Add missing curl dependency

### DIFF
--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -8,25 +8,25 @@
       become: true
       apt:
         name: 
+          - apt-listchanges
           - apt-transport-https
+          - apticron
+          - audispd-plugins
+          - auditd
           - ca-certificates
+          - clamav
+          - clamav-daemon
+          - clamav-freshclam
+          - fail2ban
           - host
           - kbtin
-          - ntp
           - libpam-pwquality
-          - unattended-upgrades
-          - apt-listchanges
-          - apticron
-          - ufw
-          - psad
-          - fail2ban
+          - mailutils
           - msmtp
           - msmtp-mta
-          - mailutils
-          - clamav
-          - clamav-freshclam
-          - clamav-daemon
+          - ntp
+          - psad
           - rkhunter
-          - auditd
-          - audispd-plugins
+          - ufw
+          - unattended-upgrades
         state: present

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -17,6 +17,7 @@
           - clamav
           - clamav-daemon
           - clamav-freshclam
+          - curl
           - fail2ban
           - host
           - kbtin


### PR DESCRIPTION
I also sorted the packages alphabetically, feel free to omit that commit if you don't think it's a good idea; I find it best to maintain some (any) fixed deterministic order for source-code like this.

`curl` is necessary for the lynis prep task:

https://github.com/moltenbit/How-To-Secure-A-Linux-Server-With-Ansible/blob/37315ab363a03ba6bbef566c04e06cc2ba6c2884/roles/lynis/tasks/main.yml#L16